### PR TITLE
Fixed UnicodeDecodeError for setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('requirements.txt', "r") as f:
 with open('test_requirements.txt', "r") as f:
     test_requirements = f.read().splitlines()
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
It appears that the README.md has emojis, and the open() didn't pass any encoding, which threw off our installation.